### PR TITLE
Add multi-project support

### DIFF
--- a/ditto/text.json
+++ b/ditto/text.json
@@ -1,585 +1,594 @@
 {
-  "project_name": "Dittobnb",
-  "frames": {
-    "hero_header": {
-      "frameName": "Hero",
-      "blocks": {
-        "navigation": {
-          "nav_link": {
-            "text": "Places to stay",
-            "tags": [
-              "TOP_NAV",
-              "CATEGORY"
-            ]
+  "projects": {
+    "project_601cc3515be42cc3f6f8ac40": {
+      "project_name": "Dittobnb",
+      "frames": {
+        "hero_header": {
+          "frameName": "Hero",
+          "blocks": {
+            "navigation": {
+              "nav_link": {
+                "text": "Locations",
+                "tags": [
+                  "TOP_NAV",
+                  "CATEGORY"
+                ]
+              },
+              "experiences_option_longer_and_longer": {
+                "text": "Experiences",
+                "tags": [
+                  "TOP_NAV",
+                  "CATEGORY"
+                ]
+              },
+              "text_601cc35c5be42cc3f6f8ac51": {
+                "text": "Online Experiences",
+                "tags": [
+                  "TOP_NAV",
+                  "CATEGORY"
+                ]
+              },
+              "become_a_host": {
+                "text": "Become a host"
+              }
+            },
+            "hero": {
+              "hero_h1": {
+                "text": "Go anywhere you'd like!",
+                "tags": [
+                  "H1"
+                ]
+              },
+              "text_601cc35c5be42cc3f6f8ac46": {
+                "text": "Book places to stay and things to explore in the community.",
+                "status": "REVIEW",
+                "tags": [
+                  "SUBTEXT",
+                  "LANDING"
+                ],
+                "notes": "Ideally no longer than 20 words"
+              },
+              "hero_cta": {
+                "text": "Explore stays",
+                "tags": [
+                  "CTA"
+                ]
+              }
+            },
+            "search_bar": {
+              "text_601cc35c5be42cc3f6f8ac49": {
+                "text": "Location",
+                "status": "FINAL",
+                "tags": [
+                  "LABEL"
+                ]
+              },
+              "text_601cc35c5be42cc3f6f8ac4b": {
+                "text": "Where are you going?",
+                "tags": [
+                  "SUBTEXT"
+                ]
+              },
+              "text_601cc35c5be42cc3f6f8ac4d": {
+                "text": "Check in",
+                "status": "FINAL",
+                "tags": [
+                  "LABEL"
+                ]
+              },
+              "text_601cc35c5be42cc3f6f8ac47": {
+                "text": "Add dates",
+                "tags": [
+                  "SUBTEXT"
+                ]
+              },
+              "text_601cc35c5be42cc3f6f8ac4a": {
+                "text": "Check out",
+                "status": "FINAL",
+                "tags": [
+                  "LABEL"
+                ]
+              },
+              "text_601cc35c5be42cc3f6f8ac48": {
+                "text": "Add dates",
+                "tags": [
+                  "SUBTEXT"
+                ]
+              },
+              "text_601cc35c5be42cc3f6f8ac4e": {
+                "text": "Guests",
+                "tags": [
+                  "LABEL"
+                ]
+              },
+              "add_guests": {
+                "text": "Add guests!",
+                "status": "WIP",
+                "tags": [
+                  "SUBTEXT",
+                  "LANDING"
+                ],
+                "notes": "Max char limit: 10"
+              }
+            }
           },
-          "experiences_option_longer_and_longer": {
-            "text": "Experiences",
-            "tags": [
-              "TOP_NAV",
-              "CATEGORY"
-            ]
-          },
-          "text_601cc35c5be42cc3f6f8ac51": {
-            "text": "Online Experiences",
-            "tags": [
-              "TOP_NAV",
-              "CATEGORY"
-            ]
-          },
-          "become_a_host": {
-            "text": "Become a host"
+          "otherText": {
+            "text_601cc3f55be42cc3f6f8ad30": {
+              "text": "dittobnb"
+            }
           }
         },
-        "hero": {
-          "hero_h1": {
-            "text": "Go Anywhere",
-            "tags": [
-              "H1"
-            ]
+        "frame_601cc35d5be42cc3f6f8ad16": {
+          "frameName": "Body",
+          "blocks": {
+            "home_types": {
+              "text_601cc35c5be42cc3f6f8ac54": {
+                "text": "Live anywhere",
+                "tags": [
+                  "H2"
+                ]
+              },
+              "text_601cc35c5be42cc3f6f8ac56": {
+                "text": "Entire homes"
+              },
+              "text_601cc35c5be42cc3f6f8ac57": {
+                "text": "Cabins and cottages"
+              },
+              "text_601cc35c5be42cc3f6f8ac58": {
+                "text": "Unique stays"
+              },
+              "text_601cc35c5be42cc3f6f8ac59": {
+                "text": "Pets welcome"
+              }
+            },
+            "online_experiences": {
+              "text_601cc35c5be42cc3f6f8ac5a": {
+                "text": "Online Experiences",
+                "tags": [
+                  "H2"
+                ]
+              },
+              "online_exp_cta": {
+                "text": "Explore all",
+                "tags": [
+                  "CTA"
+                ]
+              },
+              "text_601cc35c5be42cc3f6f8ac62": {
+                "text": "Try cooking with farm-to-table chefs",
+                "tags": [
+                  "EXAMPLE"
+                ]
+              },
+              "text_601cc35c5be42cc3f6f8ac61": {
+                "text": "Learn photography and photo editing from industry pros",
+                "tags": [
+                  "EXAMPLE"
+                ]
+              },
+              "text_601cc35c5be42cc3f6f8ac63": {
+                "text": "Experience stovetop tricks from famed hibachi artists",
+                "tags": [
+                  "EXAMPLE"
+                ]
+              },
+              "text_601cc35c5be42cc3f6f8ac60": {
+                "text": "Attend a live personal concert by local indie bands ",
+                "tags": [
+                  "EXAMPLE"
+                ]
+              }
+            },
+            "hosting": {
+              "text_601cc35c5be42cc3f6f8ac50": {
+                "text": "Join dozens of hosts on our site",
+                "status": "REVIEW",
+                "tags": [
+                  "H2"
+                ]
+              },
+              "text_601cc35c5be42cc3f6f8ac5c": {
+                "text": "Interactive activities you can do with your family, led by expert hosts",
+                "tags": [
+                  "SUBTEXT"
+                ]
+              },
+              "text_601cc35c5be42cc3f6f8ac5d": {
+                "text": "Host your own home",
+                "status": "FINAL",
+                "tags": [
+                  "CATEGORY"
+                ]
+              },
+              "text_601cc35c5be42cc3f6f8ac5e": {
+                "text": "Host an Experience",
+                "tags": [
+                  "CATEGORY"
+                ]
+              },
+              "text_601cc35c5be42cc3f6f8ac5f": {
+                "text": "Host an Online Experience",
+                "tags": [
+                  "CATEGORY"
+                ]
+              }
+            }
           },
-          "text_601cc35c5be42cc3f6f8ac46": {
-            "text": "Book unique places to stay and things to do.",
-            "status": "REVIEW",
-            "tags": [
-              "SUBTEXT",
-              "LANDING"
-            ],
-            "notes": "Ideally no longer than 20 words"
+          "otherText": {}
+        },
+        "frame_601cc35d5be42cc3f6f8ad17": {
+          "frameName": "Footer",
+          "blocks": {
+            "about": {
+              "text_601cc35c5be42cc3f6f8ac64": {
+                "text": "ABOUT",
+                "tags": [
+                  "FOOTER_HEADER"
+                ]
+              },
+              "text_601cc35c5be42cc3f6f8ac73": {
+                "text": "Company",
+                "tags": [
+                  "LINK"
+                ]
+              },
+              "text_601cc35c5be42cc3f6f8ac75": {
+                "text": "Press",
+                "tags": [
+                  "LINK"
+                ]
+              },
+              "text_601cc35c5be42cc3f6f8ac76": {
+                "text": "Blog",
+                "tags": [
+                  "LINK"
+                ]
+              },
+              "text_601cc35c5be42cc3f6f8ac77": {
+                "text": "Careers",
+                "tags": [
+                  "LINK"
+                ]
+              }
+            },
+            "community": {
+              "text_601cc35c5be42cc3f6f8ac65": {
+                "text": "COMMUNITY",
+                "tags": [
+                  "FOOTER_HEADER"
+                ]
+              },
+              "text_601cc35c5be42cc3f6f8ac71": {
+                "text": "Accessibility",
+                "tags": [
+                  "LINK"
+                ]
+              },
+              "text_601cc35c5be42cc3f6f8ac70": {
+                "text": "Guest community",
+                "tags": [
+                  "LINK"
+                ]
+              },
+              "text_601cc35c5be42cc3f6f8ac74": {
+                "text": "Invite your friends",
+                "status": "REVIEW",
+                "tags": [
+                  "LINK"
+                ]
+              },
+              "text_601cc35c5be42cc3f6f8ac72": {
+                "text": "Share your stay",
+                "tags": [
+                  "LINK"
+                ]
+              }
+            },
+            "host": {
+              "text_601cc35c5be42cc3f6f8ac66": {
+                "text": "HOST",
+                "tags": [
+                  "FOOTER_HEADER"
+                ]
+              },
+              "text_601cc35c5be42cc3f6f8ac6a": {
+                "text": "Host your own home",
+                "status": "FINAL",
+                "tags": [
+                  "CATEGORY"
+                ]
+              },
+              "text_601cc35c5be42cc3f6f8ac6c": {
+                "text": "Host an Experience",
+                "tags": [
+                  "CATEGORY",
+                  "LINK"
+                ]
+              },
+              "text_601cc35c5be42cc3f6f8ac6d": {
+                "text": "Host an Online Experience",
+                "tags": [
+                  "CATEGORY",
+                  "LINK"
+                ]
+              },
+              "text_601cc35c5be42cc3f6f8ac6e": {
+                "text": "Refer hosts",
+                "tags": [
+                  "LINK"
+                ]
+              },
+              "text_601cc35c5be42cc3f6f8ac6f": {
+                "text": "Host resources",
+                "tags": [
+                  "LINK"
+                ]
+              }
+            },
+            "support": {
+              "text_601cc35c5be42cc3f6f8ac67": {
+                "text": "SUPPORT",
+                "tags": [
+                  "FOOTER_HEADER"
+                ]
+              },
+              "text_601cc35c5be42cc3f6f8ac68": {
+                "text": "Help Center",
+                "tags": [
+                  "LINK"
+                ]
+              },
+              "text_601cc35c5be42cc3f6f8ac69": {
+                "text": "Trust and Safety",
+                "tags": [
+                  "LINK"
+                ]
+              },
+              "text_601cc35c5be42cc3f6f8ac6b": {
+                "text": "Cancellation Options",
+                "tags": [
+                  "LINK"
+                ]
+              }
+            }
           },
-          "hero_cta": {
-            "text": "Explore our stays",
-            "tags": [
-              "CTA"
-            ]
+          "otherText": {}
+        },
+        "frame_601cc35d5be42cc3f6f8ad18": {
+          "frameName": "App",
+          "blocks": {
+            "booking": {
+              "text_601cc35d5be42cc3f6f8ac82": {
+                "text": "Check in"
+              },
+              "add_dates_button": {
+                "text": "Add dates"
+              },
+              "text_601cc35d5be42cc3f6f8ac84": {
+                "text": "Check out"
+              },
+              "text_601cc35d5be42cc3f6f8ac86": {
+                "text": "Add dates"
+              },
+              "text_601cc35d5be42cc3f6f8ac85": {
+                "text": "Guests"
+              },
+              "text_601cc35d5be42cc3f6f8ac87": {
+                "text": "Add guests"
+              },
+              "text_601cc35d5be42cc3f6f8ac88": {
+                "text": "Check Availability",
+                "status": "FINAL",
+                "tags": [
+                  "CTA"
+                ]
+              }
+            },
+            "amenities": {
+              "text_601cc35d5be42cc3f6f8ac89": {
+                "text": "Entire home"
+              },
+              "text_601cc35d5be42cc3f6f8ac8a": {
+                "text": "You’ll have the house to yourself.",
+                "status": "WIP"
+              },
+              "text_601cc35d5be42cc3f6f8ac8c": {
+                "text": "Pool"
+              },
+              "text_601cc35d5be42cc3f6f8ac8b": {
+                "text": "This stay has a pool for its guests."
+              },
+              "text_601cc35d5be42cc3f6f8ac8d": {
+                "text": "Anytime cancellation"
+              },
+              "text_601cc35d5be42cc3f6f8ac8e": {
+                "text": "You can cancel at any point before your trip."
+              },
+              "text_601cc35d5be42cc3f6f8ac8f": {
+                "text": "Work friendly"
+              },
+              "text_601cc35d5be42cc3f6f8ac90": {
+                "text": "This stay has wifi and workspace accomodations."
+              }
+            },
+            "ratings": {
+              "text_601cc35d5be42cc3f6f8ac9b": {
+                "text": "Communication"
+              },
+              "text_601cc35d5be42cc3f6f8ac9c": {
+                "text": "Location"
+              },
+              "text_601cc35d5be42cc3f6f8ac9f": {
+                "text": "Value"
+              },
+              "text_601cc35d5be42cc3f6f8ac9d": {
+                "text": "Accuracy"
+              },
+              "text_601cc35d5be42cc3f6f8ac9e": {
+                "text": "Check-in"
+              },
+              "text_601cc35d5be42cc3f6f8ac9a": {
+                "text": "Cleanliness"
+              }
+            },
+            "other_options": {
+              "text_601cc35d5be42cc3f6f8aca0": {
+                "text": "Explore other options nearby"
+              },
+              "text_601cc35d5be42cc3f6f8aca1": {
+                "text": "Apartments • Houses • Lofts • Barns • Spaceships"
+              }
+            },
+            "reviews": {
+              "text_601cc35d5be42cc3f6f8ac7d": {
+                "text": "4.7 (12)"
+              },
+              "text_601cc35d5be42cc3f6f8ac94": {
+                "text": "5.0"
+              }
+            },
+            "search": {
+              "text_601cc35c5be42cc3f6f8ac79": {
+                "text": "dittobnb"
+              }
+            }
+          },
+          "otherText": {
+            "text_601cc35d5be42cc3f6f8ac7f": {
+              "text": "Start your search"
+            },
+            "text_601cc35c5be42cc3f6f8ac78": {
+              "text": "Become a host"
+            },
+            "text_601cc35c5be42cc3f6f8ac7a": {
+              "text": "Bright and Spacious Modern Villa"
+            },
+            "text_601cc35d5be42cc3f6f8ac7e": {
+              "text": "Superhost"
+            },
+            "text_601cc35d5be42cc3f6f8ac7c": {
+              "text": "Smallville, CA, United States"
+            },
+            "text_601cc35d5be42cc3f6f8ac92": {
+              "text": "Show all photos",
+              "tags": [
+                "CTA"
+              ]
+            },
+            "text_601cc35d5be42cc3f6f8ac7b": {
+              "text": "Entire house hosted by Janet"
+            },
+            "text_601cc35d5be42cc3f6f8ac83": {
+              "text": "$148 / night"
+            },
+            "text_601cc35d5be42cc3f6f8ac80": {
+              "text": "4.7 (12)"
+            },
+            "text_601cc35d5be42cc3f6f8ac91": {
+              "text": "4 guests • 2 bedrooms • 2 beds • 1 bath"
+            },
+            "text_601cc35d5be42cc3f6f8ac95": {
+              "text": "4.7 (12 Reviews)"
+            },
+            "text_601cc35d5be42cc3f6f8ac93": {
+              "text": "5.0"
+            },
+            "text_601cc35d5be42cc3f6f8ac96": {
+              "text": "5.0"
+            },
+            "text_601cc35d5be42cc3f6f8ac98": {
+              "text": "5.0"
+            },
+            "text_601cc35d5be42cc3f6f8ac97": {
+              "text": "5.0"
+            },
+            "text_601cc35d5be42cc3f6f8ac99": {
+              "text": "5.0"
+            }
           }
         },
-        "search_bar": {
-          "text_601cc35c5be42cc3f6f8ac49": {
-            "text": "Location",
-            "status": "FINAL",
-            "tags": [
-              "LABEL"
-            ]
+        "Frame_601cc35d5be42cc3f6f8ad19": {
+          "frameName": "Hosts Hero",
+          "blocks": {
+            "hero": {
+              "text_601cc35d5be42cc3f6f8aca3": {
+                "text": "Host your home on Dittobnb",
+                "tags": [
+                  "H1"
+                ]
+              },
+              "text_601cc35d5be42cc3f6f8aca4": {
+                "text": "Join a vibrant community of hosts, create memorble experiences for travelers, and earn money to pursue the things you love. ",
+                "tags": [
+                  "SUBTEXT"
+                ]
+              },
+              "text_601cc35d5be42cc3f6f8aca6d": {
+                "text": "Get Started",
+                "tags": [
+                  "CTA"
+                ]
+              },
+              "text_601cc35d5be42cc3f6f8aca5": {
+                "text": "Learn about our host community",
+                "notes": "Link to host interview signups"
+              }
+            }
           },
-          "text_601cc35c5be42cc3f6f8ac4b": {
-            "text": "Where are you going?",
-            "tags": [
-              "SUBTEXT"
-            ]
-          },
-          "text_601cc35c5be42cc3f6f8ac4d": {
-            "text": "Check in",
-            "status": "FINAL",
-            "tags": [
-              "LABEL"
-            ]
-          },
-          "text_601cc35c5be42cc3f6f8ac47": {
-            "text": "Add dates",
-            "tags": [
-              "SUBTEXT"
-            ]
-          },
-          "text_601cc35c5be42cc3f6f8ac4a": {
-            "text": "Check out",
-            "status": "FINAL",
-            "tags": [
-              "LABEL"
-            ]
-          },
-          "text_601cc35c5be42cc3f6f8ac48": {
-            "text": "Add dates",
-            "tags": [
-              "SUBTEXT"
-            ]
-          },
-          "text_601cc35c5be42cc3f6f8ac4e": {
-            "text": "Guests",
-            "tags": [
-              "LABEL"
-            ]
-          },
-          "text_601cc35c5be42cc3f6f8ac4f": {
-            "text": "Add guests",
-            "tags": [
-              "SUBTEXT"
-            ]
+          "otherText": {
+            "text_601cc35d5be42cc3f6f8aca2": {
+              "text": "dittobnb"
+            }
           }
-        }
-      },
-      "otherText": {
-        "text_601cc3f55be42cc3f6f8ad30": {
-          "text": "dittobnb"
+        },
+        "frame_601cc35d5be42cc3f6f8ad1a": {
+          "frameName": "Hosts Blurb",
+          "blocks": {
+            "passion": {
+              "text_601cc35d5be42cc3f6f8aca9": {
+                "text": "SEE WHAT’S POSSIBLE",
+                "tags": [
+                  "SUBHEADER"
+                ],
+                "notes": "All caps above header"
+              },
+              "text_601cc35d5be42cc3f6f8aca8": {
+                "text": "Share your passion for hospitality—become a host",
+                "tags": [
+                  "H2"
+                ]
+              },
+              "text_601cc35d5be42cc3f6f8acaa": {
+                "text": "Create a listing that fits your hosting style—we'll give you tips to make your place shine. Start now and finish any time.",
+                "tags": [
+                  "SUBTEXT"
+                ]
+              }
+            },
+            "ready_to_host": {
+              "text_601cc35d5be42cc3f6f8aca7": {
+                "text": "Ready to host?",
+                "tags": [
+                  "H2"
+                ]
+              },
+              "text_601cc35d5be42cc3f6f8acab": {
+                "text": "Dittobnb hosts get to share their experiences, perspectives, and spaces with travelers across the world.",
+                "tags": [
+                  "SUBTEXT"
+                ]
+              },
+              "text_601cc35d5be42cc3f6f8acac": {
+                "text": "Get Started",
+                "tags": [
+                  "CTA"
+                ]
+              }
+            }
+          },
+          "otherText": {}
         }
       }
-    },
-    "frame_601cc35d5be42cc3f6f8ad16": {
-      "frameName": "Body",
-      "blocks": {
-        "home_types": {
-          "text_601cc35c5be42cc3f6f8ac54": {
-            "text": "Live anywhere",
-            "tags": [
-              "H2"
-            ]
-          },
-          "text_601cc35c5be42cc3f6f8ac56": {
-            "text": "Entire homes"
-          },
-          "text_601cc35c5be42cc3f6f8ac57": {
-            "text": "Cabins and cottages"
-          },
-          "text_601cc35c5be42cc3f6f8ac58": {
-            "text": "Unique stays"
-          },
-          "text_601cc35c5be42cc3f6f8ac59": {
-            "text": "Pets welcome"
-          }
-        },
-        "online_experiences": {
-          "text_601cc35c5be42cc3f6f8ac5a": {
-            "text": "Online Experiences",
-            "tags": [
-              "H2"
-            ]
-          },
-          "online_exp_cta": {
-            "text": "Explore all",
-            "tags": [
-              "CTA"
-            ]
-          },
-          "text_601cc35c5be42cc3f6f8ac62": {
-            "text": "Try cooking with farm-to-table chefs",
-            "tags": [
-              "EXAMPLE"
-            ]
-          },
-          "text_601cc35c5be42cc3f6f8ac61": {
-            "text": "Learn photography and photo editing from industry pros",
-            "tags": [
-              "EXAMPLE"
-            ]
-          },
-          "text_601cc35c5be42cc3f6f8ac63": {
-            "text": "Experience stovetop tricks from famed hibachi artists",
-            "tags": [
-              "EXAMPLE"
-            ]
-          },
-          "text_601cc35c5be42cc3f6f8ac60": {
-            "text": "Attend a live personal concert by local indie bands ",
-            "tags": [
-              "EXAMPLE"
-            ]
-          }
-        },
-        "hosting": {
-          "text_601cc35c5be42cc3f6f8ac50": {
-            "text": "Join dozens of hosts on our site",
-            "status": "REVIEW",
-            "tags": [
-              "H2"
-            ]
-          },
-          "text_601cc35c5be42cc3f6f8ac5c": {
-            "text": "Interactive activities you can do with your family, led by expert hosts",
-            "tags": [
-              "SUBTEXT"
-            ]
-          },
-          "text_601cc35c5be42cc3f6f8ac5d": {
-            "text": "Host your own home",
-            "status": "FINAL",
-            "tags": [
-              "CATEGORY"
-            ]
-          },
-          "text_601cc35c5be42cc3f6f8ac5e": {
-            "text": "Host an Experience",
-            "tags": [
-              "CATEGORY"
-            ]
-          },
-          "text_601cc35c5be42cc3f6f8ac5f": {
-            "text": "Host an Online Experience",
-            "tags": [
-              "CATEGORY"
-            ]
-          }
-        }
-      },
-      "otherText": {}
-    },
-    "frame_601cc35d5be42cc3f6f8ad17": {
-      "frameName": "Footer",
-      "blocks": {
-        "about": {
-          "text_601cc35c5be42cc3f6f8ac64": {
-            "text": "ABOUT",
-            "tags": [
-              "FOOTER_HEADER"
-            ]
-          },
-          "text_601cc35c5be42cc3f6f8ac73": {
-            "text": "Company",
-            "tags": [
-              "LINK"
-            ]
-          },
-          "text_601cc35c5be42cc3f6f8ac75": {
-            "text": "Press",
-            "tags": [
-              "LINK"
-            ]
-          },
-          "text_601cc35c5be42cc3f6f8ac76": {
-            "text": "Blog",
-            "tags": [
-              "LINK"
-            ]
-          },
-          "text_601cc35c5be42cc3f6f8ac77": {
-            "text": "Careers",
-            "tags": [
-              "LINK"
-            ]
-          }
-        },
-        "community": {
-          "text_601cc35c5be42cc3f6f8ac65": {
-            "text": "COMMUNITY",
-            "tags": [
-              "FOOTER_HEADER"
-            ]
-          },
-          "text_601cc35c5be42cc3f6f8ac71": {
-            "text": "Accessibility",
-            "tags": [
-              "LINK"
-            ]
-          },
-          "text_601cc35c5be42cc3f6f8ac70": {
-            "text": "Guest community",
-            "tags": [
-              "LINK"
-            ]
-          },
-          "text_601cc35c5be42cc3f6f8ac74": {
-            "text": "Invite your friends",
-            "status": "REVIEW",
-            "tags": [
-              "LINK"
-            ]
-          },
-          "text_601cc35c5be42cc3f6f8ac72": {
-            "text": "Share your stay",
-            "tags": [
-              "LINK"
-            ]
-          }
-        },
-        "host": {
-          "text_601cc35c5be42cc3f6f8ac66": {
-            "text": "HOST",
-            "tags": [
-              "FOOTER_HEADER"
-            ]
-          },
-          "text_601cc35c5be42cc3f6f8ac6a": {
-            "text": "Host your own home",
-            "status": "FINAL",
-            "tags": [
-              "CATEGORY"
-            ]
-          },
-          "text_601cc35c5be42cc3f6f8ac6c": {
-            "text": "Host an Experience",
-            "tags": [
-              "CATEGORY",
-              "LINK"
-            ]
-          },
-          "text_601cc35c5be42cc3f6f8ac6d": {
-            "text": "Host an Online Experience",
-            "tags": [
-              "CATEGORY",
-              "LINK"
-            ]
-          },
-          "text_601cc35c5be42cc3f6f8ac6e": {
-            "text": "Refer hosts",
-            "tags": [
-              "LINK"
-            ]
-          },
-          "text_601cc35c5be42cc3f6f8ac6f": {
-            "text": "Host resources",
-            "tags": [
-              "LINK"
-            ]
-          }
-        },
-        "support": {
-          "text_601cc35c5be42cc3f6f8ac67": {
-            "text": "SUPPORT",
-            "tags": [
-              "FOOTER_HEADER"
-            ]
-          },
-          "text_601cc35c5be42cc3f6f8ac68": {
-            "text": "Help Center",
-            "tags": [
-              "LINK"
-            ]
-          },
-          "text_601cc35c5be42cc3f6f8ac69": {
-            "text": "Trust and Safety",
-            "tags": [
-              "LINK"
-            ]
-          },
-          "text_601cc35c5be42cc3f6f8ac6b": {
-            "text": "Cancellation Options",
-            "tags": [
-              "LINK"
-            ]
-          }
-        }
-      },
-      "otherText": {}
-    },
-    "frame_601cc35d5be42cc3f6f8ad18": {
-      "frameName": "App",
-      "blocks": {
-        "booking": {
-          "text_601cc35d5be42cc3f6f8ac82": {
-            "text": "Check in"
-          },
-          "add_dates_button": {
-            "text": "Add dates"
-          },
-          "text_601cc35d5be42cc3f6f8ac84": {
-            "text": "Check out"
-          },
-          "text_601cc35d5be42cc3f6f8ac86": {
-            "text": "Add dates"
-          },
-          "text_601cc35d5be42cc3f6f8ac85": {
-            "text": "Guests"
-          },
-          "text_601cc35d5be42cc3f6f8ac87": {
-            "text": "Add guests"
-          },
-          "text_601cc35d5be42cc3f6f8ac88": {
-            "text": "Check Availability",
-            "status": "FINAL",
-            "tags": [
-              "CTA"
-            ]
-          }
-        },
-        "amenities": {
-          "text_601cc35d5be42cc3f6f8ac89": {
-            "text": "Entire home"
-          },
-          "text_601cc35d5be42cc3f6f8ac8a": {
-            "text": "You’ll have the house to yourself.",
-            "status": "WIP"
-          },
-          "text_601cc35d5be42cc3f6f8ac8c": {
-            "text": "Pool"
-          },
-          "text_601cc35d5be42cc3f6f8ac8b": {
-            "text": "This stay has a pool for its guests."
-          },
-          "text_601cc35d5be42cc3f6f8ac8d": {
-            "text": "Anytime cancellation"
-          },
-          "text_601cc35d5be42cc3f6f8ac8e": {
-            "text": "You can cancel at any point before your trip."
-          },
-          "text_601cc35d5be42cc3f6f8ac8f": {
-            "text": "Work friendly"
-          },
-          "text_601cc35d5be42cc3f6f8ac90": {
-            "text": "This stay has wifi and workspace accomodations."
-          }
-        },
-        "ratings": {
-          "text_601cc35d5be42cc3f6f8ac9b": {
-            "text": "Communication"
-          },
-          "text_601cc35d5be42cc3f6f8ac9c": {
-            "text": "Location"
-          },
-          "text_601cc35d5be42cc3f6f8ac9f": {
-            "text": "Value"
-          },
-          "text_601cc35d5be42cc3f6f8ac9d": {
-            "text": "Accuracy"
-          },
-          "text_601cc35d5be42cc3f6f8ac9e": {
-            "text": "Check-in"
-          },
-          "text_601cc35d5be42cc3f6f8ac9a": {
-            "text": "Cleanliness"
-          }
-        },
-        "other_options": {
-          "text_601cc35d5be42cc3f6f8aca0": {
-            "text": "Explore other options nearby"
-          },
-          "text_601cc35d5be42cc3f6f8aca1": {
-            "text": "Apartments • Houses • Lofts • Barns • Spaceships"
-          }
-        },
-        "reviews": {
-          "text_601cc35d5be42cc3f6f8ac7d": {
-            "text": "4.7 (12)"
-          },
-          "text_601cc35d5be42cc3f6f8ac94": {
-            "text": "5.0"
-          }
-        }
-      },
-      "otherText": {
-        "text_601cc35c5be42cc3f6f8ac79": {
-          "text": "dittobnb"
-        },
-        "text_601cc35d5be42cc3f6f8ac7f": {
-          "text": "Start your search"
-        },
-        "text_601cc35c5be42cc3f6f8ac78": {
-          "text": "Become a host"
-        },
-        "text_601cc35c5be42cc3f6f8ac7a": {
-          "text": "Bright and Spacious Modern Villa"
-        },
-        "text_601cc35d5be42cc3f6f8ac7e": {
-          "text": "Superhost"
-        },
-        "text_601cc35d5be42cc3f6f8ac7c": {
-          "text": "Smallville, CA, United States"
-        },
-        "text_601cc35d5be42cc3f6f8ac92": {
-          "text": "Show all photos",
-          "tags": [
-            "CTA"
-          ]
-        },
-        "text_601cc35d5be42cc3f6f8ac7b": {
-          "text": "Entire house hosted by Janet"
-        },
-        "text_601cc35d5be42cc3f6f8ac83": {
-          "text": "$148 / night"
-        },
-        "text_601cc35d5be42cc3f6f8ac80": {
-          "text": "4.7 (12)"
-        },
-        "text_601cc35d5be42cc3f6f8ac91": {
-          "text": "4 guests • 2 bedrooms • 2 beds • 1 bath"
-        },
-        "text_601cc35d5be42cc3f6f8ac95": {
-          "text": "4.7 (12 Reviews)"
-        },
-        "text_601cc35d5be42cc3f6f8ac93": {
-          "text": "5.0"
-        },
-        "text_601cc35d5be42cc3f6f8ac96": {
-          "text": "5.0"
-        },
-        "text_601cc35d5be42cc3f6f8ac98": {
-          "text": "5.0"
-        },
-        "text_601cc35d5be42cc3f6f8ac97": {
-          "text": "5.0"
-        },
-        "text_601cc35d5be42cc3f6f8ac99": {
-          "text": "5.0"
-        }
-      }
-    },
-    "Frame_601cc35d5be42cc3f6f8ad19": {
-      "frameName": "Hosts Hero",
-      "blocks": {
-        "hero": {
-          "text_601cc35d5be42cc3f6f8aca3": {
-            "text": "Host your home on Dittobnb",
-            "tags": [
-              "H1"
-            ]
-          },
-          "text_601cc35d5be42cc3f6f8aca4": {
-            "text": "Join a vibrant community of hosts, create memorble experiences for travelers, and earn money to pursue the things you love. ",
-            "tags": [
-              "SUBTEXT"
-            ]
-          },
-          "text_601cc35d5be42cc3f6f8aca6d": {
-            "text": "Get Started",
-            "tags": [
-              "CTA"
-            ]
-          },
-          "text_601cc35d5be42cc3f6f8aca5": {
-            "text": "Learn about our host community",
-            "notes": "Link to host interview signups"
-          }
-        }
-      },
-      "otherText": {
-        "text_601cc35d5be42cc3f6f8aca2": {
-          "text": "dittobnb"
-        }
-      }
-    },
-    "frame_601cc35d5be42cc3f6f8ad1a": {
-      "frameName": "Hosts Blurb",
-      "blocks": {
-        "passion": {
-          "text_601cc35d5be42cc3f6f8aca9": {
-            "text": "SEE WHAT’S POSSIBLE",
-            "tags": [
-              "SUBHEADER"
-            ],
-            "notes": "All caps above header"
-          },
-          "text_601cc35d5be42cc3f6f8aca8": {
-            "text": "Share your passion for hospitality—become a host",
-            "tags": [
-              "H2"
-            ]
-          },
-          "text_601cc35d5be42cc3f6f8acaa": {
-            "text": "Create a listing that fits your hosting style—we'll give you tips to make your place shine. Start now and finish any time.",
-            "tags": [
-              "SUBTEXT"
-            ]
-          }
-        },
-        "ready_to_host": {
-          "text_601cc35d5be42cc3f6f8aca7": {
-            "text": "Ready to host?",
-            "tags": [
-              "H2"
-            ]
-          },
-          "text_601cc35d5be42cc3f6f8acab": {
-            "text": "Dittobnb hosts get to share their experiences, perspectives, and spaces with travelers across the world.",
-            "tags": [
-              "SUBTEXT"
-            ]
-          },
-          "text_601cc35d5be42cc3f6f8acac": {
-            "text": "Get Started",
-            "tags": [
-              "CTA"
-            ]
-          }
-        }
-      },
-      "otherText": {}
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "classnames": "^2.2.6",
     "css-loader": "^0.28.11",
     "cssnano": "^4.0.0",
-    "ditto-react": "^0.0.2",
+    "ditto-react": "^0.0.4",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "file-loader": "^1.1.11",

--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
     "webpack": "^5.21.0",
     "webpack-dev-middleware": "^3.0.1",
     "webpack-hot-middleware": "^2.25.0"
+  },
+  "devDependencies": {
+    "@jordin/react-library-testing": "^0.0.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,8 +30,5 @@
     "webpack": "^5.21.0",
     "webpack-dev-middleware": "^3.0.1",
     "webpack-hot-middleware": "^2.25.0"
-  },
-  "devDependencies": {
-    "@jordin/react-library-testing": "^0.0.4"
   }
 }

--- a/src/components/app/app.jsx
+++ b/src/components/app/app.jsx
@@ -21,14 +21,14 @@ const App = () => {
     <div>
       <Router history={history}>
         <Switch>
-          <Route path="/landing">
-            <Landing/>
-          </Route>
           <Route path="/listing">
             <Listing/>
           </Route>
           <Route path="/hosts">
             <Hosts/>
+          </Route>
+          <Route>
+            <Landing />
           </Route>
         </Switch>
       </Router>

--- a/src/components/footer/index.jsx
+++ b/src/components/footer/index.jsx
@@ -6,10 +6,7 @@ import { Ditto } from 'ditto-react';
 
 const Footer = ({}) => {
   return <div className={style.footer}>
-    <Ditto
-      projectId="project_601cc3515be42cc3f6f8ac40"
-      frameId="frame_601cc35d5be42cc3f6f8ad17"
-    >
+    <Ditto frameId="frame_601cc35d5be42cc3f6f8ad17">
       {( frame ) => {
         return Object.keys(frame.blocks).map((blockId) => (
           <div className={style.footerCol} key={blockId}>

--- a/src/components/footer/index.jsx
+++ b/src/components/footer/index.jsx
@@ -7,6 +7,7 @@ import { Ditto } from 'ditto-react';
 const Footer = ({}) => {
   return <div className={style.footer}>
     <Ditto
+      projectId="project_601cc3515be42cc3f6f8ac40"
       frameId="frame_601cc35d5be42cc3f6f8ad17"
     >
       {( frame ) => {

--- a/src/components/landing/landing.jsx
+++ b/src/components/landing/landing.jsx
@@ -9,7 +9,7 @@ import DittoProvider, { Ditto } from 'ditto-react';
 
 const Landing = ({}) => {
   return <div className={style.body}>
-    <DittoProvider source={source}>
+    <DittoProvider projectId="project_601cc3515be42cc3f6f8ac40" source={source}>
       <div className={style.header}>
         <div className={style.nav}>
           <div className={style.logo}>
@@ -17,7 +17,6 @@ const Landing = ({}) => {
           </div>
           <div className={style.links}>
             <Ditto
-              projectId="project_601cc3515be42cc3f6f8ac40"
               frameId="hero_header"
               blockId="navigation"
               filters={{ tags: ["TOP_NAV"]}}
@@ -33,7 +32,6 @@ const Landing = ({}) => {
         </div>
         <div className={style.hero}>
           <Ditto 
-            projectId="project_601cc3515be42cc3f6f8ac40"
             frameId="hero_header" 
             blockId="hero"
           >
@@ -51,43 +49,43 @@ const Landing = ({}) => {
       </div>
       <div className={classnames(style.section, style.light)}>
         <h2>
-          <Ditto projectId="project_601cc3515be42cc3f6f8ac40" textId="text_601cc35c5be42cc3f6f8ac54"/>
+          <Ditto textId="text_601cc35c5be42cc3f6f8ac54"/>
         </h2>
         <div className={style.gallery}>
           <div className={style.card4}>
             <div className={classnames(style.img, style.liveAnywhere0)}></div>
             <div className={style.label}>
-              <Ditto projectId="project_601cc3515be42cc3f6f8ac40" textId="text_601cc35c5be42cc3f6f8ac56"/>
+              <Ditto textId="text_601cc35c5be42cc3f6f8ac56"/>
             </div>
           </div>
           <div className={style.card4}>
             <div className={classnames(style.img, style.liveAnywhere1)}></div>
             <div className={style.label}>
-              <Ditto projectId="project_601cc3515be42cc3f6f8ac40" textId="text_601cc35c5be42cc3f6f8ac57"/>
+              <Ditto textId="text_601cc35c5be42cc3f6f8ac57"/>
             </div>
           </div>
           <div className={style.card4}>
             <div className={classnames(style.img, style.liveAnywhere2)}></div>
             <div className={style.label}>
-              <Ditto projectId="project_601cc3515be42cc3f6f8ac40" textId="text_601cc35c5be42cc3f6f8ac58"/>
+              <Ditto textId="text_601cc35c5be42cc3f6f8ac58"/>
             </div>
           </div>
           <div className={style.card4}>
             <div className={classnames(style.img, style.liveAnywhere3)}></div>
             <div className={style.label}>
-              <Ditto projectId="project_601cc3515be42cc3f6f8ac40" textId="text_601cc35c5be42cc3f6f8ac59"/>
+              <Ditto textId="text_601cc35c5be42cc3f6f8ac59"/>
             </div>
           </div>
         </div>
 
       </div>
       <div className={classnames(style.section, style.dark)}>
-        <h2><Ditto projectId="project_601cc3515be42cc3f6f8ac40" textId="text_601cc35c5be42cc3f6f8ac5a"/></h2>
+        <h2><Ditto textId="text_601cc35c5be42cc3f6f8ac5a"/></h2>
         <div className={style.gallery}>
           <div className={style.card2}>
             <div className={classnames(style.img, style.onlineexp1)}>
               <div className={classnames(style.label, style.caption)}>
-                <Ditto projectId="project_601cc3515be42cc3f6f8ac40" textId="text_601cc35c5be42cc3f6f8ac60"/>
+                <Ditto textId="text_601cc35c5be42cc3f6f8ac60"/>
               </div>
             </div>
           </div>
@@ -96,14 +94,14 @@ const Landing = ({}) => {
               <div className={style.card2}>
                 <div className={classnames(style.img, style.onlineexp2)}>
                   <div className={classnames(style.label, style.caption)}>
-                    <Ditto projectId="project_601cc3515be42cc3f6f8ac40" textId="text_601cc35c5be42cc3f6f8ac63"/>
+                    <Ditto textId="text_601cc35c5be42cc3f6f8ac63"/>
                   </div>
                 </div>
               </div>
               <div className={style.card2}>
                 <div className={classnames(style.img, style.onlineexp3)}>
                   <div className={classnames(style.label, style.caption)}>
-                    <Ditto projectId="project_601cc3515be42cc3f6f8ac40" textId="text_601cc35c5be42cc3f6f8ac62"/>
+                    <Ditto textId="text_601cc35c5be42cc3f6f8ac62"/>
                   </div>
                 </div>
               </div>
@@ -111,7 +109,7 @@ const Landing = ({}) => {
             <div className={style.card1}>
               <div className={classnames(style.img, style.onlineexp4)}>
                 <div className={classnames(style.label, style.caption)}>
-                  <Ditto projectId="project_601cc3515be42cc3f6f8ac40" textId="text_601cc35c5be42cc3f6f8ac63"/>
+                  <Ditto textId="text_601cc35c5be42cc3f6f8ac63"/>
                 </div>
               </div>
             </div>
@@ -119,24 +117,24 @@ const Landing = ({}) => {
         </div>
       </div>
       <div className={classnames(style.section, style.light)}>
-        <h2><Ditto projectId="project_601cc3515be42cc3f6f8ac40" textId="text_601cc35c5be42cc3f6f8ac50"/></h2>
+        <h2><Ditto textId="text_601cc35c5be42cc3f6f8ac50"/></h2>
         <div className={style.gallery}>
           <div className={style.card3}>
             <div className={classnames(style.img, style.hosts0)}></div>
             <div className={style.label}>
-              <Ditto projectId="project_601cc3515be42cc3f6f8ac40" textId="text_601cc35c5be42cc3f6f8ac5d"/>
+              <Ditto textId="text_601cc35c5be42cc3f6f8ac5d"/>
             </div>
           </div>
           <div className={style.card3}>
             <div className={classnames(style.img, style.hosts1)}></div>
             <div className={style.label}>
-              <Ditto projectId="project_601cc3515be42cc3f6f8ac40" textId="text_601cc35c5be42cc3f6f8ac5e"/>
+              <Ditto textId="text_601cc35c5be42cc3f6f8ac5e"/>
             </div>
           </div>
           <div className={style.card3}>
             <div className={classnames(style.img, style.hosts2)}></div>
             <div className={style.label}>
-              <Ditto projectId="project_601cc3515be42cc3f6f8ac40" textId="text_601cc35c5be42cc3f6f8ac5f"/>
+              <Ditto textId="text_601cc35c5be42cc3f6f8ac5f"/>
             </div>
           </div>
         </div>

--- a/src/components/landing/landing.jsx
+++ b/src/components/landing/landing.jsx
@@ -17,6 +17,7 @@ const Landing = ({}) => {
           </div>
           <div className={style.links}>
             <Ditto
+              projectId="project_601cc3515be42cc3f6f8ac40"
               frameId="hero_header"
               blockId="navigation"
               filters={{ tags: ["TOP_NAV"]}}
@@ -31,7 +32,11 @@ const Landing = ({}) => {
           <div>Become a host</div>
         </div>
         <div className={style.hero}>
-          <Ditto frameId="hero_header" blockId="hero">
+          <Ditto 
+            projectId="project_601cc3515be42cc3f6f8ac40"
+            frameId="hero_header" 
+            blockId="hero"
+          >
             {({
               hero_h1, text_601cc35c5be42cc3f6f8ac46, hero_cta
             }) => (
@@ -45,42 +50,44 @@ const Landing = ({}) => {
         </div>
       </div>
       <div className={classnames(style.section, style.light)}>
-        <h2><Ditto textId="text_601cc35c5be42cc3f6f8ac54"/></h2>
+        <h2>
+          <Ditto projectId="project_601cc3515be42cc3f6f8ac40" textId="text_601cc35c5be42cc3f6f8ac54"/>
+        </h2>
         <div className={style.gallery}>
           <div className={style.card4}>
             <div className={classnames(style.img, style.liveAnywhere0)}></div>
             <div className={style.label}>
-              <Ditto textId="text_601cc35c5be42cc3f6f8ac56"/>
+              <Ditto projectId="project_601cc3515be42cc3f6f8ac40" textId="text_601cc35c5be42cc3f6f8ac56"/>
             </div>
           </div>
           <div className={style.card4}>
             <div className={classnames(style.img, style.liveAnywhere1)}></div>
             <div className={style.label}>
-              <Ditto textId="text_601cc35c5be42cc3f6f8ac57"/>
+              <Ditto projectId="project_601cc3515be42cc3f6f8ac40" textId="text_601cc35c5be42cc3f6f8ac57"/>
             </div>
           </div>
           <div className={style.card4}>
             <div className={classnames(style.img, style.liveAnywhere2)}></div>
             <div className={style.label}>
-              <Ditto textId="text_601cc35c5be42cc3f6f8ac58"/>
+              <Ditto projectId="project_601cc3515be42cc3f6f8ac40" textId="text_601cc35c5be42cc3f6f8ac58"/>
             </div>
           </div>
           <div className={style.card4}>
             <div className={classnames(style.img, style.liveAnywhere3)}></div>
             <div className={style.label}>
-              <Ditto textId="text_601cc35c5be42cc3f6f8ac59"/>
+              <Ditto projectId="project_601cc3515be42cc3f6f8ac40" textId="text_601cc35c5be42cc3f6f8ac59"/>
             </div>
           </div>
         </div>
 
       </div>
       <div className={classnames(style.section, style.dark)}>
-        <h2><Ditto textId="text_601cc35c5be42cc3f6f8ac5a"/></h2>
+        <h2><Ditto projectId="project_601cc3515be42cc3f6f8ac40" textId="text_601cc35c5be42cc3f6f8ac5a"/></h2>
         <div className={style.gallery}>
           <div className={style.card2}>
             <div className={classnames(style.img, style.onlineexp1)}>
               <div className={classnames(style.label, style.caption)}>
-                <Ditto textId="text_601cc35c5be42cc3f6f8ac60"/>
+                <Ditto projectId="project_601cc3515be42cc3f6f8ac40" textId="text_601cc35c5be42cc3f6f8ac60"/>
               </div>
             </div>
           </div>
@@ -89,14 +96,14 @@ const Landing = ({}) => {
               <div className={style.card2}>
                 <div className={classnames(style.img, style.onlineexp2)}>
                   <div className={classnames(style.label, style.caption)}>
-                    <Ditto textId="text_601cc35c5be42cc3f6f8ac63"/>
+                    <Ditto projectId="project_601cc3515be42cc3f6f8ac40" textId="text_601cc35c5be42cc3f6f8ac63"/>
                   </div>
                 </div>
               </div>
               <div className={style.card2}>
                 <div className={classnames(style.img, style.onlineexp3)}>
                   <div className={classnames(style.label, style.caption)}>
-                    <Ditto textId="text_601cc35c5be42cc3f6f8ac62"/>
+                    <Ditto projectId="project_601cc3515be42cc3f6f8ac40" textId="text_601cc35c5be42cc3f6f8ac62"/>
                   </div>
                 </div>
               </div>
@@ -104,7 +111,7 @@ const Landing = ({}) => {
             <div className={style.card1}>
               <div className={classnames(style.img, style.onlineexp4)}>
                 <div className={classnames(style.label, style.caption)}>
-                  <Ditto textId="text_601cc35c5be42cc3f6f8ac63"/>
+                  <Ditto projectId="project_601cc3515be42cc3f6f8ac40" textId="text_601cc35c5be42cc3f6f8ac63"/>
                 </div>
               </div>
             </div>
@@ -112,24 +119,24 @@ const Landing = ({}) => {
         </div>
       </div>
       <div className={classnames(style.section, style.light)}>
-        <h2><Ditto textId="text_601cc35c5be42cc3f6f8ac50"/></h2>
+        <h2><Ditto projectId="project_601cc3515be42cc3f6f8ac40" textId="text_601cc35c5be42cc3f6f8ac50"/></h2>
         <div className={style.gallery}>
           <div className={style.card3}>
             <div className={classnames(style.img, style.hosts0)}></div>
             <div className={style.label}>
-              <Ditto textId="text_601cc35c5be42cc3f6f8ac5d"/>
+              <Ditto projectId="project_601cc3515be42cc3f6f8ac40" textId="text_601cc35c5be42cc3f6f8ac5d"/>
             </div>
           </div>
           <div className={style.card3}>
             <div className={classnames(style.img, style.hosts1)}></div>
             <div className={style.label}>
-              <Ditto textId="text_601cc35c5be42cc3f6f8ac5e"/>
+              <Ditto projectId="project_601cc3515be42cc3f6f8ac40" textId="text_601cc35c5be42cc3f6f8ac5e"/>
             </div>
           </div>
           <div className={style.card3}>
             <div className={classnames(style.img, style.hosts2)}></div>
             <div className={style.label}>
-              <Ditto textId="text_601cc35c5be42cc3f6f8ac5f"/>
+              <Ditto projectId="project_601cc3515be42cc3f6f8ac40" textId="text_601cc35c5be42cc3f6f8ac5f"/>
             </div>
           </div>
         </div>

--- a/src/components/listing/listing.jsx
+++ b/src/components/listing/listing.jsx
@@ -9,7 +9,7 @@ import DittoProvider, { Ditto } from 'ditto-react';
 
 const Listing = ({}) => {
   return <div className={style.body}>
-    <DittoProvider source={source}>
+    <DittoProvider projectId="project_601cc3515be42cc3f6f8ac40" source={source}>
       <div className={style.nav}>
         <div className={style.logo}>
           <img src={logo}/>
@@ -17,7 +17,7 @@ const Listing = ({}) => {
         <div>Become a host</div>
       </div>
       <div className={style.header}>
-        <h1><Ditto projectId="project_601cc3515be42cc3f6f8ac40" textId="text_601cc35c5be42cc3f6f8ac7a"/></h1>
+        <h1><Ditto textId="text_601cc35c5be42cc3f6f8ac7a"/></h1>
       </div>
       <div className={style.images}>
         <div className={classnames(style.img, style.img1)}></div>
@@ -36,15 +36,14 @@ const Listing = ({}) => {
         <div className={style.listing}>
           <div className={style.listingInfo}>
             <h3>
-              <Ditto projectId="project_601cc3515be42cc3f6f8ac40" textId="text_601cc35d5be42cc3f6f8ac7b"/>
+              <Ditto textId="text_601cc35d5be42cc3f6f8ac7b"/>
             </h3>
-            <Ditto projectId="project_601cc3515be42cc3f6f8ac40" textId="text_601cc35d5be42cc3f6f8ac91"/>
+            <Ditto textId="text_601cc35d5be42cc3f6f8ac91"/>
             <br/>
             <hr/>
             <br/>
             <Ditto
-              projectId="project_601cc3515be42cc3f6f8ac40"
-              frameId="listing_app"
+              frameId="frame_601cc35d5be42cc3f6f8ad18"
               blockId="amenities"
             >
               {( block ) => {
@@ -62,19 +61,19 @@ const Listing = ({}) => {
               </div>
               <div className={style.select1}>
                 <div className={style.select}>
-                  <div className={style.label}><Ditto projectId="project_601cc3515be42cc3f6f8ac40" textId="text_601cc35d5be42cc3f6f8ac82"/></div>
-                  <div className={style.placeholder}><Ditto textId="text_601cc35d5be42cc3f6f8ac81"/></div>
+                  <div className={style.label}><Ditto textId="text_601cc35d5be42cc3f6f8ac82"/></div>
+                  <div className={style.placeholder}><Ditto textId="add_dates_button"/></div>
                 </div>
                 <div className={style.select}>
-                  <div className={style.label}><Ditto projectId="project_601cc3515be42cc3f6f8ac40" textId="text_601cc35d5be42cc3f6f8ac84"/></div>
-                  <div className={style.placeholder}><Ditto projectId="project_601cc3515be42cc3f6f8ac40" textId="text_601cc35d5be42cc3f6f8ac86"/></div>
+                  <div className={style.label}><Ditto textId="text_601cc35d5be42cc3f6f8ac84"/></div>
+                  <div className={style.placeholder}><Ditto textId="text_601cc35d5be42cc3f6f8ac86"/></div>
                 </div>
               </div>
               <div className={style.select2}>
-                <div className={style.label}><Ditto projectId="project_601cc3515be42cc3f6f8ac40" textId="text_601cc35d5be42cc3f6f8ac85"/></div>
-                <div className={style.placeholder}><Ditto projectId="project_601cc3515be42cc3f6f8ac40" textId="text_601cc35d5be42cc3f6f8ac87"/></div>
+                <div className={style.label}><Ditto textId="text_601cc35d5be42cc3f6f8ac85"/></div>
+                <div className={style.placeholder}><Ditto textId="text_601cc35d5be42cc3f6f8ac87"/></div>
               </div>
-              <button><Ditto projectId="project_601cc3515be42cc3f6f8ac40" textId="text_601cc35d5be42cc3f6f8ac88"/></button>
+              <button><Ditto textId="text_601cc35d5be42cc3f6f8ac88"/></button>
             </div>
           </div>
         </div>
@@ -82,8 +81,8 @@ const Listing = ({}) => {
         </div>
       </div>
       <div className={style.otherOptions}>
-        <h4><Ditto projectId="project_601cc3515be42cc3f6f8ac40" textId="text_601cc35d5be42cc3f6f8aca0"/></h4>
-        <div><Ditto projectId="project_601cc3515be42cc3f6f8ac40" textId="text_601cc35d5be42cc3f6f8aca1"/></div>
+        <h4><Ditto textId="text_601cc35d5be42cc3f6f8aca0"/></h4>
+        <div><Ditto textId="text_601cc35d5be42cc3f6f8aca1"/></div>
       </div>
       <Footer/>
     </DittoProvider>

--- a/src/components/listing/listing.jsx
+++ b/src/components/listing/listing.jsx
@@ -17,7 +17,7 @@ const Listing = ({}) => {
         <div>Become a host</div>
       </div>
       <div className={style.header}>
-        <h1><Ditto textId="text_601cc35c5be42cc3f6f8ac7a"/></h1>
+        <h1><Ditto projectId="project_601cc3515be42cc3f6f8ac40" textId="text_601cc35c5be42cc3f6f8ac7a"/></h1>
       </div>
       <div className={style.images}>
         <div className={classnames(style.img, style.img1)}></div>
@@ -35,12 +35,15 @@ const Listing = ({}) => {
       <div className={style.info}>
         <div className={style.listing}>
           <div className={style.listingInfo}>
-            <h3><Ditto textId="text_601cc35d5be42cc3f6f8ac7b"/></h3>
-            <Ditto textId="text_601cc35d5be42cc3f6f8ac91"/>
+            <h3>
+              <Ditto projectId="project_601cc3515be42cc3f6f8ac40" textId="text_601cc35d5be42cc3f6f8ac7b"/>
+            </h3>
+            <Ditto projectId="project_601cc3515be42cc3f6f8ac40" textId="text_601cc35d5be42cc3f6f8ac91"/>
             <br/>
             <hr/>
             <br/>
             <Ditto
+              projectId="project_601cc3515be42cc3f6f8ac40"
               frameId="listing_app"
               blockId="amenities"
             >
@@ -59,19 +62,19 @@ const Listing = ({}) => {
               </div>
               <div className={style.select1}>
                 <div className={style.select}>
-                  <div className={style.label}><Ditto textId="text_601cc35d5be42cc3f6f8ac82"/></div>
+                  <div className={style.label}><Ditto projectId="project_601cc3515be42cc3f6f8ac40" textId="text_601cc35d5be42cc3f6f8ac82"/></div>
                   <div className={style.placeholder}><Ditto textId="text_601cc35d5be42cc3f6f8ac81"/></div>
                 </div>
                 <div className={style.select}>
-                  <div className={style.label}><Ditto textId="text_601cc35d5be42cc3f6f8ac84"/></div>
-                  <div className={style.placeholder}><Ditto textId="text_601cc35d5be42cc3f6f8ac86"/></div>
+                  <div className={style.label}><Ditto projectId="project_601cc3515be42cc3f6f8ac40" textId="text_601cc35d5be42cc3f6f8ac84"/></div>
+                  <div className={style.placeholder}><Ditto projectId="project_601cc3515be42cc3f6f8ac40" textId="text_601cc35d5be42cc3f6f8ac86"/></div>
                 </div>
               </div>
               <div className={style.select2}>
-                <div className={style.label}><Ditto textId="text_601cc35d5be42cc3f6f8ac85"/></div>
-                <div className={style.placeholder}><Ditto textId="text_601cc35d5be42cc3f6f8ac87"/></div>
+                <div className={style.label}><Ditto projectId="project_601cc3515be42cc3f6f8ac40" textId="text_601cc35d5be42cc3f6f8ac85"/></div>
+                <div className={style.placeholder}><Ditto projectId="project_601cc3515be42cc3f6f8ac40" textId="text_601cc35d5be42cc3f6f8ac87"/></div>
               </div>
-              <button><Ditto textId="text_601cc35d5be42cc3f6f8ac88"/></button>
+              <button><Ditto projectId="project_601cc3515be42cc3f6f8ac40" textId="text_601cc35d5be42cc3f6f8ac88"/></button>
             </div>
           </div>
         </div>
@@ -79,8 +82,8 @@ const Listing = ({}) => {
         </div>
       </div>
       <div className={style.otherOptions}>
-        <h4><Ditto textId="text_601cc35d5be42cc3f6f8aca0"/></h4>
-        <div><Ditto textId="text_601cc35d5be42cc3f6f8aca1"/></div>
+        <h4><Ditto projectId="project_601cc3515be42cc3f6f8ac40" textId="text_601cc35d5be42cc3f6f8aca0"/></h4>
+        <div><Ditto projectId="project_601cc3515be42cc3f6f8ac40" textId="text_601cc35d5be42cc3f6f8aca1"/></div>
       </div>
       <Footer/>
     </DittoProvider>

--- a/webpackConfig.js
+++ b/webpackConfig.js
@@ -138,6 +138,9 @@ module.exports = (env, argv) => {
         'node_modules',
         path.resolve(__dirname, 'node_modules'),
       ],
+      alias: {
+        "ditto-react": path.resolve(__dirname, "node_modules/@jordin/react-library-testing")
+      }
     },
     output: {
       path: path.join(__dirname, 'dist'),

--- a/webpackConfig.js
+++ b/webpackConfig.js
@@ -138,9 +138,6 @@ module.exports = (env, argv) => {
         'node_modules',
         path.resolve(__dirname, 'node_modules'),
       ],
-      alias: {
-        "ditto-react": path.resolve(__dirname, "node_modules/@jordin/react-library-testing")
-      }
     },
     output: {
       path: path.join(__dirname, 'dist'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2002,10 +2002,10 @@ dir-glob@2.0.0:
     arrify "^1.0.1"
     path-type "^3.0.0"
 
-ditto-react@^0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/ditto-react/-/ditto-react-0.0.2.tgz#c3bf7a6e912e3b3e885ec9f9e98e9f20975184d4"
-  integrity sha512-3QsrC3X9vLZ7gpMk7hEAvWUi/nuMIjk2LG01w4YC67MLJCykDW3+9tKpWc21KEUODMnxOldIHdgAVBJid+mTNA==
+ditto-react@^0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/ditto-react/-/ditto-react-0.0.4.tgz#179a89138c808833119e4e1bdf144afc99a6c3d4"
+  integrity sha512-NL+ro3jTYxTeUvDq89UL9kODEh0qqzknWaDvNg8UVXYjD5/Dz6GnLNj/vgFIkF6WbxS+1h9qw/6JOLgbAqP0Rg==
 
 dom-converter@^0.2:
   version "0.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -863,6 +863,11 @@
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
+"@jordin/react-library-testing@^0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@jordin/react-library-testing/-/react-library-testing-0.0.4.tgz#cdd3bd490e82ed5b11cc33699ebcad0a3e230986"
+  integrity sha512-X9AHwntXboSWteoVmkXdeyEVqppR+JV7ZB4HmGDRIiITjxt0eg1wkyqVnBq96PqpRi0TVYJhMc9rFtTh6B70JQ==
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"

--- a/yarn.lock
+++ b/yarn.lock
@@ -863,11 +863,6 @@
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
-"@jordin/react-library-testing@^0.0.4":
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/@jordin/react-library-testing/-/react-library-testing-0.0.4.tgz#cdd3bd490e82ed5b11cc33699ebcad0a3e230986"
-  integrity sha512-X9AHwntXboSWteoVmkXdeyEVqppR+JV7ZB4HmGDRIiITjxt0eg1wkyqVnBq96PqpRi0TVYJhMc9rFtTh6B70JQ==
-
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"


### PR DESCRIPTION
## Overview
**This PR shouldn't be merged until https://github.com/dittowords/ditto-react/pull/2 has been merged, the newest version of `ditto-react` has been published to NPM, and the `ditto-react` version in `package.json` has been updated**

This PR:
- adds support for the multi-project JSON that is now stored in `text.json` by the latest version of the CLI
- updates the existing frame, block, and text ids to be current with the Dittobnb Ditto project (`601cc3515be42cc3f6f8ac40`)
- renders the landing page by default, so no more blank screens at the root of the app!

## Remaining TODOs
- [x] After the newest version of `react-ditto` has been published:
>- [x] Revert d7fa813
>- [x] Update dependencies to pull latest version of `ditto-react`

## Context
This [Notion doc](https://www.notion.so/dittov3/Pulling-Multiple-Files-via-CLI-3437c51c811844e1a1a579bf23d3e5e8) contains the original spec for the changes made to the API, CLI, and React SDK for pulling multiple files.

## Linear Issues
- https://linear.app/dittowords/issue/DIT-63/update-ditto-demo-to-support-multi-project-json